### PR TITLE
Normalize embeddings for models that require it

### DIFF
--- a/app/src/main/java/com/projects/shubham0204/demo/Config.kt
+++ b/app/src/main/java/com/projects/shubham0204/demo/Config.kt
@@ -5,7 +5,8 @@ data class ModelConfig(
     val modelAssetsFilepath: String,
     val tokenizerAssetsFilepath: String,
     val useTokenTypeIds: Boolean,
-    val outputTensorName: String
+    val outputTensorName: String,
+    val normalizeEmbeddings: Boolean
 )
 
 enum class Model {
@@ -20,22 +21,25 @@ fun getModelConfig(model: Model): ModelConfig {
             modelName = "all-minilm-l6-v2",
             modelAssetsFilepath = "all-minilm-l6-v2/model.onnx",
             tokenizerAssetsFilepath = "all-minilm-l6-v2/tokenizer.json",
-            useTokenTypeIds = false,
-            outputTensorName = "sentence_embedding"
+            useTokenTypeIds = true,
+            outputTensorName = "last_hidden_state",
+            normalizeEmbeddings = true
         )
         Model.BGE_SMALL_EN_V1_5 -> ModelConfig(
             modelName = "bge-small-en-v1.5",
             modelAssetsFilepath = "bge-small-en-v1_5/model.onnx",
             tokenizerAssetsFilepath = "bge-small-en-v1_5/tokenizer.json",
             useTokenTypeIds = true,
-            outputTensorName = "last_hidden_state"
+            outputTensorName = "last_hidden_state",
+            normalizeEmbeddings = true
         )
         Model.SNOWFLAKE_ARCTIC_EMBED_S -> ModelConfig(
             modelName = "snowflake-arctic-embed-s",
             modelAssetsFilepath = "snowflake-arctic-embed-s/model.onnx",
             tokenizerAssetsFilepath = "snowflake-arctic-embed-s/tokenizer.json",
             useTokenTypeIds = true,
-            outputTensorName = "last_hidden_state"
+            outputTensorName = "last_hidden_state",
+            normalizeEmbeddings = true
         )
     }
 }

--- a/app/src/main/java/com/projects/shubham0204/demo/MainActivity.kt
+++ b/app/src/main/java/com/projects/shubham0204/demo/MainActivity.kt
@@ -225,15 +225,13 @@ class MainActivity : ComponentActivity() {
         val sentenceEmbeddings = Collections.synchronizedList(mutableListOf<FloatArray>())
         listOf(
             launch { sentenceEmbeddings.add(sentenceEmbedding.encode(sentence1)) } ,
-            //launch { sentenceEmbeddings.add(sentenceEmbedding.encode(sentence2)) }
+            launch { sentenceEmbeddings.add(sentenceEmbedding.encode(sentence2)) }
         ).joinAll()
 
-        Log.d("Size", sentenceEmbeddings[0].size.toString())
-        Log.d("Size", sentenceEmbeddings[0].contentToString())
-        //val cosineSimilarity = cosineDistance(sentenceEmbeddings[0],sentenceEmbeddings[1])
+        val cosineSimilarity = cosineDistance(sentenceEmbeddings[0],sentenceEmbeddings[1])
         val inferenceTime = System.currentTimeMillis() - t1
         hideProgressDialog()
-        return@withContext Pair(1.0f,inferenceTime)
+        return@withContext Pair(cosineSimilarity,inferenceTime)
     }
 
     private fun cosineDistance(

--- a/app/src/main/java/com/projects/shubham0204/demo/MainActivity.kt
+++ b/app/src/main/java/com/projects/shubham0204/demo/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.projects.shubham0204.demo
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -46,7 +47,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
-import java.nio.file.Files
 import java.util.Collections
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -91,7 +91,8 @@ class MainActivity : ComponentActivity() {
                                         copyAndReturnPath(config.modelAssetsFilepath),
                                         copyAndReturnBytes(config.tokenizerAssetsFilepath),
                                         useTokenTypeIds = config.useTokenTypeIds,
-                                        outputTensorName = config.outputTensorName
+                                        outputTensorName = config.outputTensorName,
+                                        normalizeEmbeddings = config.normalizeEmbeddings
                                     )
                                     isModelLoaded = true
                                 }
@@ -224,12 +225,15 @@ class MainActivity : ComponentActivity() {
         val sentenceEmbeddings = Collections.synchronizedList(mutableListOf<FloatArray>())
         listOf(
             launch { sentenceEmbeddings.add(sentenceEmbedding.encode(sentence1)) } ,
-            launch { sentenceEmbeddings.add(sentenceEmbedding.encode(sentence2)) }
+            //launch { sentenceEmbeddings.add(sentenceEmbedding.encode(sentence2)) }
         ).joinAll()
-        val cosineSimilarity = cosineDistance(sentenceEmbeddings[0],sentenceEmbeddings[1])
+
+        Log.d("Size", sentenceEmbeddings[0].size.toString())
+        Log.d("Size", sentenceEmbeddings[0].contentToString())
+        //val cosineSimilarity = cosineDistance(sentenceEmbeddings[0],sentenceEmbeddings[1])
         val inferenceTime = System.currentTimeMillis() - t1
         hideProgressDialog()
-        return@withContext Pair(cosineSimilarity,inferenceTime)
+        return@withContext Pair(1.0f,inferenceTime)
     }
 
     private fun cosineDistance(

--- a/sentence_embeddings/src/main/java/com/ml/shubham0204/sentence_embeddings/SentenceEmbedding.kt
+++ b/sentence_embeddings/src/main/java/com/ml/shubham0204/sentence_embeddings/SentenceEmbedding.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.LongBuffer
 import java.util.EnumSet
+import kotlin.math.max
 
 class SentenceEmbedding {
 
@@ -17,6 +18,7 @@ class SentenceEmbedding {
     private lateinit var ortSession: OrtSession
     private var useTokenTypeIds: Boolean = false
     private var outputTensorName: String = ""
+    private var normalizedEmbedding: Boolean = false
 
     suspend fun init(
         modelFilepath: String,
@@ -24,7 +26,8 @@ class SentenceEmbedding {
         useTokenTypeIds: Boolean,
         outputTensorName: String,
         useFP16: Boolean = false,
-        useXNNPack: Boolean = false
+        useXNNPack: Boolean = false,
+        normalizeEmbeddings: Boolean
     ) = withContext(Dispatchers.IO) {
         hfTokenizer = HFTokenizer(tokenizerBytes)
         ortEnvironment = OrtEnvironment.getEnvironment()
@@ -41,6 +44,7 @@ class SentenceEmbedding {
         ortSession = ortEnvironment.createSession(modelFilepath,options)
         this@SentenceEmbedding.useTokenTypeIds = useTokenTypeIds
         this@SentenceEmbedding.outputTensorName = outputTensorName
+        this@SentenceEmbedding.normalizedEmbedding = normalizeEmbeddings
         Log.d(SentenceEmbedding::class.simpleName, "Input Names: " + ortSession.inputNames.toList())
         Log.d(SentenceEmbedding::class.simpleName, "Output Names: " + ortSession.outputNames.toList())
     }
@@ -74,8 +78,53 @@ class SentenceEmbedding {
             inputTensorMap["token_type_ids"] = tokenTypeIdsTensor
         }
         val outputs = ortSession.run(inputTensorMap)
-        val embeddingTensor = outputs.get(outputTensorName).get() as OnnxTensor
-        return@withContext embeddingTensor.floatBuffer.array()
+        if(normalizedEmbedding) {
+            val tokenEmbeddings3D = outputs.get(0).value as Array<Array<FloatArray>> // Change to 3D array
+
+            val tokenEmbeddings = tokenEmbeddings3D[0]
+
+            val pooledEmbeddings = meanPooling(tokenEmbeddings, result.attentionMask)
+
+            val normalizedEmbedding = normalize(pooledEmbeddings)
+
+            return@withContext normalizedEmbedding
+        } else {
+
+            val embeddingTensor = outputs.get(outputTensorName).get() as OnnxTensor
+
+            return@withContext embeddingTensor.floatBuffer.array()
+        }
+    }
+
+    private fun meanPooling(tokenEmbeddings: Array<FloatArray>, attentionMask: LongArray): FloatArray {
+        val pooledEmbeddings = FloatArray(tokenEmbeddings[0].size) { 0f }
+        var validTokenCount = 0
+
+        for (i in tokenEmbeddings.indices) {
+            if (attentionMask[i] == 1L) { // Check if the token is valid
+                validTokenCount++
+                for (j in tokenEmbeddings[i].indices) {
+                    pooledEmbeddings[j] += tokenEmbeddings[i][j]
+                }
+            }
+        }
+
+        // Avoid division by zero
+        val divisor = max(validTokenCount, 1)
+        for (j in pooledEmbeddings.indices) {
+            pooledEmbeddings[j] /= divisor.toFloat()
+        }
+
+        return pooledEmbeddings
+    }
+
+    // Function to normalize embeddings
+    private fun normalize(embeddings: FloatArray): FloatArray {
+        // Calculate the L2 norm (Euclidean norm)
+        val norm = Math.sqrt(embeddings.sumOf { it * it.toDouble() }).toFloat()
+
+        // Normalize each embedding by dividing by the norm
+        return embeddings.map { it / norm }.toFloatArray()
     }
 
     fun close() {


### PR DESCRIPTION
This PR fixes embeddings for models that requires the embeddings to be mean pooled and normalized. Further, the minilm-l2 had configuration issues in config.kt which has been corrected.

Here's the colab results using same model and example string from this repo:
https://gist.github.com/VijaiCPrasad/8c3593d8cb7dc2775b3c8baac92e7c00

Fixes #6 